### PR TITLE
Add controller to update infrastructure status

### DIFF
--- a/cmd/hypershift-operator/main.go
+++ b/cmd/hypershift-operator/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/clusteroperator"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/clusterversion"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/cmca"
+	"github.com/openshift-hive/hypershift-operator/pkg/controllers/infrastatus"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/kubeadminpwd"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/kubelet_serving_ca"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/openshift_apiserver"
@@ -47,6 +48,7 @@ var controllerFuncs = map[string]operator.ControllerSetupFunc{
 	"openshift-apiserver":          openshift_apiserver.Setup,
 	"openshift-controller-manager": openshift_controller_manager.Setup,
 	"route-sync":                   routesync.Setup,
+	"infrastatus":                  infrastatus.Setup,
 }
 
 type ControlPlaneOperator struct {

--- a/pkg/controllers/infrastatus/reconcile.go
+++ b/pkg/controllers/infrastatus/reconcile.go
@@ -1,0 +1,74 @@
+package infrastatus
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/go-logr/logr"
+
+	kubeclient "k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	configlister "github.com/openshift/client-go/config/listers/config/v1"
+)
+
+type InfraStatusReconciler struct {
+	Source     *configv1.Infrastructure
+	Client     configclient.Interface
+	KubeClient kubeclient.Interface
+	Lister     configlister.InfrastructureLister
+	Log        logr.Logger
+
+	m              sync.Mutex
+	hasSubresource *bool
+}
+
+func (r *InfraStatusReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	proceed, err := r.shouldReconcile()
+	if err != nil || !proceed {
+		return ctrl.Result{}, err
+	}
+	if req.Name != "cluster" {
+		r.Log.Info("Unexpected infrastructure instance name", "name", req.Name)
+		return ctrl.Result{}, nil
+	}
+	r.Log.Info("Reconciling", "name", req.NamespacedName.String())
+	existing, err := r.Lister.Get(req.Name)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot fetch infrastructure %s: %v", req.Name, err)
+	}
+	updated := existing.DeepCopy()
+	r.Source.Status.DeepCopyInto(&updated.Status)
+
+	if reflect.DeepEqual(updated.Status, existing.Status) {
+		return ctrl.Result{}, nil
+	}
+	r.Log.Info("Updating infrastructure status")
+	_, err = r.Client.ConfigV1().Infrastructures().UpdateStatus(updated)
+	return ctrl.Result{}, err
+}
+
+func (r *InfraStatusReconciler) shouldReconcile() (bool, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	if r.hasSubresource != nil {
+		return *r.hasSubresource, nil
+	}
+	resourceList, err := r.KubeClient.Discovery().ServerResourcesForGroupVersion(configv1.GroupVersion.String())
+	if err != nil {
+		return false, fmt.Errorf("failed to discover resources for %s: %v", configv1.GroupVersion.String(), err)
+	}
+	result := false
+	for _, resource := range resourceList.APIResources {
+		if resource.Name == "infrastructures/status" {
+			result = true
+			break
+		}
+	}
+	r.hasSubresource = &result
+	return result, nil
+}

--- a/pkg/controllers/infrastatus/setup.go
+++ b/pkg/controllers/infrastatus/setup.go
@@ -1,0 +1,61 @@
+package infrastatus
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/openshift-hive/hypershift-operator/pkg/cmd/operator"
+)
+
+const (
+	infrastructureConfigMap = "user-manifest-cluster-infrastructure-02-config"
+)
+
+var (
+	configScheme = runtime.NewScheme()
+	configCodecs = serializer.NewCodecFactory(configScheme)
+)
+
+func init() {
+	if err := configv1.AddToScheme(configScheme); err != nil {
+		panic(err)
+	}
+}
+
+func Setup(cfg *operator.ControlPlaneOperatorConfig) error {
+	infrastructures := cfg.TargetConfigInformers().Config().V1().Infrastructures()
+	sourceInfraConfigMap, err := cfg.KubeClient().CoreV1().ConfigMaps(cfg.Namespace()).Get(infrastructureConfigMap, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot get infrastructure configmap: %v", err)
+	}
+	infrastructureRaw := sourceInfraConfigMap.Data["data"]
+	infrastructureObj, err := runtime.Decode(configCodecs.UniversalDecoder(configv1.SchemeGroupVersion), []byte(infrastructureRaw))
+	if err != nil {
+		return fmt.Errorf("cannot decode source infrastructure: %v", err)
+	}
+	sourceInfrastructure := infrastructureObj.(*configv1.Infrastructure)
+
+	reconciler := &InfraStatusReconciler{
+		Source:     sourceInfrastructure,
+		Client:     cfg.TargetConfigClient(),
+		KubeClient: cfg.TargetKubeClient(),
+		Lister:     infrastructures.Lister(),
+		Log:        cfg.Logger().WithName("InfraStatus"),
+	}
+	c, err := controller.New("infra-status", cfg.Manager(), controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return err
+	}
+	if err := c.Watch(&source.Informer{Informer: infrastructures.Informer()}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
In 4.5, the infrastructure resource has a separate status subresource, therefore status cannot be set with a simple apply. This adds a controller that will update the status of the infrastructure resource to what is in the bootstrap manifests.