### PR TITLE
Add controller to manage node labels and taints

### DIFF
--- a/cmd/hypershift-operator/main.go
+++ b/cmd/hypershift-operator/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/infrastatus"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/kubeadminpwd"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/kubelet_serving_ca"
+	"github.com/openshift-hive/hypershift-operator/pkg/controllers/node"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/openshift_apiserver"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/openshift_controller_manager"
 	"github.com/openshift-hive/hypershift-operator/pkg/controllers/routesync"
@@ -49,6 +50,7 @@ var controllerFuncs = map[string]operator.ControllerSetupFunc{
 	"openshift-controller-manager": openshift_controller_manager.Setup,
 	"route-sync":                   routesync.Setup,
 	"infrastatus":                  infrastatus.Setup,
+	"node":                         node.Setup,
 }
 
 type ControlPlaneOperator struct {

--- a/pkg/controllers/node/reconciler.go
+++ b/pkg/controllers/node/reconciler.go
@@ -1,0 +1,83 @@
+package node
+
+import (
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var requiredLabels = map[string]string{
+	"node-role.kubernetes.io/worker": "",
+	"node-role.kubernetes.io/master": "",
+}
+
+const masterTaint = "node-role.kubernetes.io/master"
+
+type NodeReconciler struct {
+	Lister     corev1lister.NodeLister
+	KubeClient kubeclient.Interface
+	Log        logr.Logger
+}
+
+func (a *NodeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	logger := a.Log.WithValues("node", req.NamespacedName.String())
+	logger.Info("Start reconcile")
+	node, err := a.Lister.Get(req.Name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if hasRequiredLabels(node) && !hasMasterTaint(node) {
+		return ctrl.Result{}, nil
+	}
+
+	for k := range requiredLabels {
+		if _, hasLabel := node.Labels[k]; hasLabel {
+			continue
+		}
+		if node.Labels == nil {
+			node.Labels = map[string]string{}
+		}
+		node.Labels[k] = requiredLabels[k]
+	}
+
+	removeMasterTaint(node)
+
+	logger.Info("Updating node")
+	_, err = a.KubeClient.CoreV1().Nodes().Update(node)
+	if err != nil {
+		a.Log.Error(err, "failed to update node")
+	}
+	return ctrl.Result{}, err
+}
+
+func hasRequiredLabels(node *corev1.Node) bool {
+	for k := range requiredLabels {
+		if _, hasLabel := node.Labels[k]; !hasLabel {
+			return false
+		}
+	}
+	return true
+}
+
+func hasMasterTaint(node *corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == masterTaint {
+			return true
+		}
+	}
+	return false
+}
+
+func removeMasterTaint(node *corev1.Node) {
+	taints := make([]corev1.Taint, 0, len(node.Spec.Taints))
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == masterTaint {
+			continue
+		}
+		taints = append(taints, taint)
+	}
+	node.Spec.Taints = taints
+}

--- a/pkg/controllers/node/setup.go
+++ b/pkg/controllers/node/setup.go
@@ -1,0 +1,34 @@
+package node
+
+import (
+	"k8s.io/client-go/informers"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift-hive/hypershift-operator/pkg/cmd/operator"
+	"github.com/openshift-hive/hypershift-operator/pkg/controllers"
+)
+
+func Setup(cfg *operator.ControlPlaneOperatorConfig) error {
+	informerFactory := informers.NewSharedInformerFactory(cfg.TargetKubeClient(), controllers.DefaultResync)
+	cfg.Manager().Add(manager.RunnableFunc(func(stopCh <-chan struct{}) error {
+		informerFactory.Start(stopCh)
+		return nil
+	}))
+	nodes := informerFactory.Core().V1().Nodes()
+	reconciler := &NodeReconciler{
+		Lister:     nodes.Lister(),
+		KubeClient: cfg.TargetKubeClient(),
+		Log:        cfg.Logger().WithName("Node"),
+	}
+	c, err := controller.New("node", cfg.Manager(), controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return err
+	}
+	if err := c.Watch(&source.Informer{Informer: nodes.Informer()}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Controller ensures that nodes have the required role labels (master & worker), and do not have a taint for masters.
This is needed to fix up nodes created using an ignition payload from MCO/MCS.